### PR TITLE
fix(ChapterPrinter & JATSReference): Modification in JATS tags

### DIFF
--- a/JATSReference.php
+++ b/JATSReference.php
@@ -18,10 +18,10 @@ class JATSReference {
         $this->ref->setAttribute('id', self::JATS_REF_ID_PREFIX.$id );
         $this->reflist->appendChild($this->ref);
         
-        $this->mixed_citation = $this->dom->createElement('mixed_citation',$this->reference->getPlainTextReference());
+        $this->mixed_citation = $this->dom->createElement('mixed-citation',$this->reference->getPlainTextReference());
 
-        $this->element_citation = $this->dom->createElement('element_citation');
-        $this->element_citation->setAttribute('publication_type',$this->reference->getTitleType());
+        $this->element_citation = $this->dom->createElement('element-citation');
+        $this->element_citation->setAttribute('publication-type',$this->reference->getTitleType());
 
         $this->ref->appendChild($this->element_citation);
         $this->ref->appendChild($this->mixed_citation);

--- a/Printer/ChapterPrinter.php
+++ b/Printer/ChapterPrinter.php
@@ -30,8 +30,8 @@ class ChapterPrinter extends TitlePrinter{
     public function createXMLElements(): array {
         $elements = [];
 
-        $parttitleElement = $this->createElement('part-title',$this->getTitle());
-        $elements[] = $parttitleElement;
+        $chapterTitleElement = $this->createElement('chapter-title',$this->getTitle());
+        $elements[] = $chapterTitleElement;
         
         $sourceElement = $this->createElement('source',$this->getSource());
         $elements[] = $sourceElement;

--- a/Printer/ThesisPrinter.php
+++ b/Printer/ThesisPrinter.php
@@ -23,7 +23,7 @@ class ThesisPrinter extends TitlePrinter implements EnrichmentInstitutionInterfa
         */
 
         $elements = [];
-        $sourceElement = $this->createElement('source',$this->getSource());
+        $sourceElement = $this->createElement('article-title',$this->getSource());
         $elements[] = $sourceElement;
 
         $commentElement = $this->createElement('comment',$this->getComment());


### PR DESCRIPTION
**_Modifications in JATSReference and ChapterPrinter._**
Bug fixes when creating "element-citation", "mixed-citation" JATS XML tags. 

 **The correct way to define these tags is:**
<element-citation></element-citation>
<mixed-citation></mixed-citation>

**Before they were defined like this:**
<element_citation></element_citation>
<mixed_citation></mixed_citation>

Also, the title of a book chapter is now saved under the XML JATS "chapter-title" tag, not under the "title" tag.