### PR TITLE
Feature/process unrecognizable references

### DIFF
--- a/Expression/Analyzers/AuthorAnalyzer/AuthorAnalyzer.php
+++ b/Expression/Analyzers/AuthorAnalyzer/AuthorAnalyzer.php
@@ -26,6 +26,10 @@ include_once('AuthorPatterns.php');
             // Smith, J. A., Johnson, M. L., Universidad Nacional de La Plata (2021
             preg_match_all($this->authorPattern, $firstPartText, $authorsMatches, PREG_SET_ORDER);
 
+            if (empty($authorsMatches)) {
+                return array('expression' => null, 'value' => '');
+            }
+
             $authors_array = array();
             $counter = 1;
             
@@ -53,7 +57,7 @@ include_once('AuthorPatterns.php');
             }
 
             //Return only $authors_array if the reference does not contain institutions as authors.
-            return array('expression' => null, 'value' => $authors_array);
+            return array('expression' => 'authors', 'value' => $authors_array);
             
         }
 

--- a/JATSReference.php
+++ b/JATSReference.php
@@ -64,7 +64,6 @@ class JATSReference {
 
         $authorType = $this->reference->getAuthorType();
         if ($authorType === null || trim($authorType) === "" || $authorType === "No match found") {
-            print_r("entro");
             $errorText = "Author. ";
             $this->addError($errorText);
             return;


### PR DESCRIPTION
Now references that cannot be parsed are saved only under the mixed-citation tag (the element-citation is NOT created). Additionally, it indicates whether the problem when parsing was in the title, authors, or date section under a comment in element-citation tag.

For example, the reference: "Vatrican, A. (2015). la modalidad en la gramática: la capacidad en las construcciones saber y poder infinitivo. Revista Española de Lingüística, 45(2), 115–141".

It has the first letter of the title with a lowercase letter after the date. Therefore, the "ref" tag will return:

      <ref id="parser_14">
        <mixed-citation>Vatrican, A. (2015). la modalidad en la gramática: la capacidad en las construcciones saber y poder infinitivo. Revista Española de Lingüística, 45(2), 115–141.<!--ERRORS FOUND IN THESE SECTIONS: "Title. "--></mixed-citation>
      </ref>

As we observed, since there was an error, only the mixed-citation is returned and within this tag, a comment indicating in which section the error is found. This will allow the texture plugin to display this message.