### PR TITLE
changes: elimination of the error comments in jats

### DIFF
--- a/JATSReference.php
+++ b/JATSReference.php
@@ -35,9 +35,8 @@ class JATSReference {
         if (trim($this->errors) !== "") {
             
             $textError = 'ERRORS FOUND IN THESE SECTIONS: "' . $this->errors . '"';
-        
-            $errorComment = $this->dom->createComment($textError);
-            $this->mixed_citation->appendChild($errorComment);
+
+            $this->mixed_citation->nodeValue .= " --- " . $textError;
             $this->ref->removeChild($this->element_citation);
         }
     }


### PR DESCRIPTION
I removed the comments in the references that have errors. Plain text now appears inside the mixed-citation tag.