### PR TITLE
Feature/new supported reference types

### DIFF
--- a/Expression/Analyzers/AuthorAnalyzer/AuthorPatterns.php
+++ b/Expression/Analyzers/AuthorAnalyzer/AuthorPatterns.php
@@ -17,7 +17,6 @@
            return $authors;
         }
         public static function getInstitutionPattern(){
-
             //Institution Pattern.
             $institution = '/(?P<institution>[\s\S]*)/';
             


### PR DESCRIPTION
Added support for other reference types: laws, journalistic notes, and websites adapted to Texture (for correct processing).

These references are stored using the 'webpage' publication type in JATS XML to ensure proper processing and recognition by the Texture plugin.